### PR TITLE
Add conversation memory

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -17,5 +17,9 @@ def ingest(req: IngestRequest):
 
 @router.post("/query", response_model=QueryResponse, tags=["rag"])
 def query(req: QueryRequest):
-    answer, contexts = rag.answer_question(req.question, top_k=req.top_k)
-    return QueryResponse(answer=answer, contexts=contexts)
+    answer, contexts, conversation_id = rag.answer_question(
+        req.question, top_k=req.top_k, conversation_id=req.conversation_id
+    )
+    return QueryResponse(
+        answer=answer, contexts=contexts, conversation_id=conversation_id
+    )

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -11,8 +11,10 @@ class IngestRequest(BaseModel):
 class QueryRequest(BaseModel):
     question: str
     top_k: Optional[int] = Field(default=4, ge=1, le=20)
+    conversation_id: Optional[str] = None
 
 
 class QueryResponse(BaseModel):
     answer: str
     contexts: List[str]
+    conversation_id: str

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -1,11 +1,13 @@
-from typing import List
+from typing import List, Optional
 from openai import OpenAI
 from app.core.config import settings
+from app.services.memory import Message
 
 _client = OpenAI(api_key=settings.OPENAI_API_KEY)
 
-
-def generate_answer(question: str, contexts: List[str]) -> str:
+def generate_answer(
+    question: str, contexts: List[str], history: Optional[List[Message]] = None
+) -> str:
     context_block = "\n\n---\n\n".join(contexts) if contexts else "N/A"
     system = (
         "You are a helpful assistant that answers strictly based on the provided context. "
@@ -17,12 +19,14 @@ def generate_answer(question: str, contexts: List[str]) -> str:
         "Answer in Korean. Include brief citations like [#1], [#2] referring to the order of context chunks if useful."
     )
 
+    messages = [{"role": "system", "content": system}]
+    if history:
+        messages.extend(history)
+    messages.append({"role": "user", "content": user})
+
     resp = _client.chat.completions.create(
         model=settings.OPENAI_MODEL,
-        messages=[
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
+        messages=messages,
         temperature=0.2,
     )
     return resp.choices[0].message.content.strip()

--- a/app/services/memory.py
+++ b/app/services/memory.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from typing import Dict, List, TypedDict
+
+
+class Message(TypedDict):
+    role: str
+    content: str
+
+
+class ConversationMemory:
+    """Simple in-memory store for chat histories."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, List[Message]] = {}
+
+    def get(self, conversation_id: str) -> List[Message]:
+        return self._store.get(conversation_id, [])
+
+    def append(self, conversation_id: str, role: str, content: str) -> None:
+        self._store.setdefault(conversation_id, []).append({"role": role, "content": content})
+
+
+memory = ConversationMemory()

--- a/app/services/rag.py
+++ b/app/services/rag.py
@@ -1,9 +1,18 @@
 from typing import List, Tuple
+from uuid import uuid4
 from app.services.retriever import retrieve
 from app.services.llm import generate_answer
+from app.services.memory import memory
 
 
-def answer_question(question: str, top_k: int | None = None) -> Tuple[str, List[str]]:
+def answer_question(
+    question: str, top_k: int | None = None, conversation_id: str | None = None
+) -> Tuple[str, List[str], str]:
+    if conversation_id is None:
+        conversation_id = str(uuid4())
+    history = memory.get(conversation_id)
     contexts, _metas = retrieve(question, top_k=top_k)
-    answer = generate_answer(question, contexts)
-    return answer, contexts
+    answer = generate_answer(question, contexts, history)
+    memory.append(conversation_id, "user", question)
+    memory.append(conversation_id, "assistant", answer)
+    return answer, contexts, conversation_id


### PR DESCRIPTION
## Summary
- maintain per-conversation history in memory service
- include conversation id in query API to support contextual dialogue

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d48a3d188321804086514b25f1d2